### PR TITLE
Minor changes

### DIFF
--- a/TLS/generate-CA.sh
+++ b/TLS/generate-CA.sh
@@ -78,7 +78,7 @@ MOSQUITTOUSER=${MOSQUITTOUSER:=$USER}
 # version of OpenSSL, run `openssl dgst -help`
 #
 # defaultmd="-sha256"
-defaultmd="-sha512"
+defaultmd="-sha256"
 
 function maxdays() {
 	nowyear=$(date +%Y)
@@ -225,7 +225,7 @@ else
 	#                            
 
 	if [ ! -f $CLIENT.key ]; then
-		echo "--- Creating server key and signing request"
+		echo "--- Creating client key and signing request"
 		$openssl genrsa -out $CLIENT.key $keybits
 
 		CNF=`mktemp /tmp/cacnf-req.XXXXXXXX` || { echo "$0: can't create temp file" >&2; exit 1; }


### PR DESCRIPTION
Default signature algorithm is sha256 in the comment, but sha512 in code.

When generating client certificate/key, the initial message prints server instead of client.